### PR TITLE
Add 'Flight Red'

### DIFF
--- a/Sources/FlightUI/Assets/Colors.xcassets/flightRed.colorset/Contents.json
+++ b/Sources/FlightUI/Assets/Colors.xcassets/flightRed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x23",
+          "green" : "0x33",
+          "red" : "0xEA"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/FlightUI/Styles/Color+Extensions.swift
+++ b/Sources/FlightUI/Styles/Color+Extensions.swift
@@ -11,6 +11,7 @@ public extension Color {
     static let flightBlue = Color("flightBlue", bundle: .module)
     static let flightYellow = Color("flightYellow", bundle: .module)
     static let flightOrange = Color("flightOrange", bundle: .module)
+    static let flightRed = Color("flightRed", bundle: .module)
 }
 
 // MARK: - FilePrivate Preview Code -
@@ -36,7 +37,8 @@ fileprivate extension Color {
                                         .flightLightGray,
                                         .flightBlue,
                                         .flightYellow,
-                                        .flightOrange]
+                                        .flightOrange,
+                                        .flightRed]
 }
 
 struct Color_Previews: PreviewProvider {

--- a/Sources/FlightUI/Validation/ValidationStatus.swift
+++ b/Sources/FlightUI/Validation/ValidationStatus.swift
@@ -12,7 +12,7 @@ public enum ValidationStatus: Equatable {
         case .warning:
             return .flightYellow
         case .error:
-            return .flightOrange
+            return .flightRed
         }
     }
 }


### PR DESCRIPTION
Add flight red as default error state as per Style Guide
Add flight red as Warning error as per [CS 25.1322 Flight Crew Alerting](https://www.easa.europa.eu/en/document-library/easy-access-rules/online-publications/easy-access-rules-large-aeroplanes-cs-25?page=42) 
<img width="632" alt="Screen Shot 2023-02-02 at 11 12 08" src="https://user-images.githubusercontent.com/12582998/216309468-5453323b-6720-43b5-ade8-ec9db5687131.png">
