### PR TITLE
[ASTRA-2996] InputFields on the edge have their validation borders slightly cropped

### DIFF
--- a/Sources/FlightUI/Components/InputField.swift
+++ b/Sources/FlightUI/Components/InputField.swift
@@ -39,9 +39,9 @@ public struct InputField: View {
                     .disabled(config.options.contains(.staticText))
                     .when(config.options.contains(.bordered)) { view in
                         view
-                            .background(
+                            .overlay(
                                 RoundedRectangle(cornerRadius: theme.staticTextFieldCornerRadius, style: .continuous)
-                                    .stroke(theme.staticTextBorder, lineWidth: theme.staticTextFieldBorderWidth)
+                                    .strokeBorder(theme.staticTextBorder, lineWidth: theme.staticTextFieldBorderWidth)
                             )
                     }
             case false:
@@ -55,9 +55,9 @@ public struct InputField: View {
                     .disabled(config.options.contains(.staticText))
                     .when(config.options.contains(.bordered)) { view in
                         view
-                            .background(
+                            .overlay(
                                 RoundedRectangle(cornerRadius: theme.staticTextFieldCornerRadius, style: .continuous)
-                                    .stroke(theme.staticTextBorder, lineWidth: theme.staticTextFieldBorderWidth)
+                                    .strokeBorder(theme.staticTextBorder, lineWidth: theme.staticTextFieldBorderWidth)
                             )
                     }
             }
@@ -72,7 +72,7 @@ public struct InputField: View {
         .overlay {
             if context.status != .valid {
                 RoundedRectangle(cornerRadius: CornerRadius().default)
-                    .stroke(overlayColor, lineWidth: theme.staticTextFieldBorderWidth)
+                    .strokeBorder(overlayColor, lineWidth: theme.staticTextFieldBorderWidth)
             }
         }
     }


### PR DESCRIPTION
### Ticket reference
This PR fixes / implements ASTRA-2996

### Changes proposed in this pull request
- Changed Input Field to Draw Borders and Validation Borders to use overlay & draw borders internally using StrokeBorder rather than Stroke. This Fixes borders not being drawn correctly & crop outs when borders are at the edge.

### Definition of Done checklist
- [x] All acceptance criteria met
- [ ] Unit tested
- [ ] UI tested
- [ ] Tested on device
- [ ] Add screenshots and / or videos to Jira ticket
- [ ] PO approved
- [ ] Design signed off


Before:
![Pasted Graphic 2](https://github.com/Royal-Air-Force/flight-ui-ios/assets/89018255/7880f372-16e7-43e9-ae1a-2d46df113cc7)
After:
![Pasted Graphic 1](https://github.com/Royal-Air-Force/flight-ui-ios/assets/89018255/53aed559-0c51-4ca8-ab7c-1a5fe62daa04)


Before On Ballistic:
![Pasted Graphic 5](https://github.com/Royal-Air-Force/flight-ui-ios/assets/89018255/23769934-f7f7-4fd3-b566-880b473175c6)
After On Ballistic:
![Pasted Graphic 4](https://github.com/Royal-Air-Force/flight-ui-ios/assets/89018255/e08627eb-1640-44f2-b099-03e59ccb57a7)
