### PR TITLE
[No-Issue] Standardise Colour Tab Title component

### DIFF
--- a/Sample/Kitchen Sink/Colours/Colours.swift
+++ b/Sample/Kitchen Sink/Colours/Colours.swift
@@ -24,7 +24,7 @@ struct Colours: View {
     
     var generalColors: some View {
         VStack{
-            ColorHeadingView(title: "General colours", subTitle: "UUsed for distinguishing content and content areas within an application")
+            ColorHeadingView(title: "General colours", subTitle: "Used for distinguishing content and content areas within an application")
             
             GeneralColorView(colorName: "Primary", generalColor: theme.color.primary, onGeneralColor: theme.color.onPrimary)
             Spacer()


### PR DESCRIPTION
- Reduces duplicate code
- Removes Core Colour swift error for 11+ elements in VStack. 